### PR TITLE
Some UPSes provides data keys with '-' inside.

### DIFF
--- a/collectors/nut_collector.go
+++ b/collectors/nut_collector.go
@@ -187,7 +187,10 @@ func (c *NutCollector) Collect(ch chan<- prometheus.Metric) {
 						continue
 					}
 
-					varDesc := prometheus.NewDesc(prometheus.BuildFQName(c.opts.Namespace, "", strings.Replace(variable.Name, ".", "_", -1)),
+					name := strings.Replace(variable.Name, ".", "_", -1)
+					name = strings.Replace(name, "-", "_", -1)
+
+					varDesc := prometheus.NewDesc(prometheus.BuildFQName(c.opts.Namespace, "", name),
 						fmt.Sprintf("%s (%s)", variable.Description, variable.Name),
 						nil, nil,
 					)


### PR DESCRIPTION
Some UPSes provides data keys with '-' inside. This leads to nut_exporter crash.
Example:
```
input.bypass.L1-N.voltage: 248
input.bypass.L2-N.voltage: 245
input.bypass.L3-N.voltage: 245
input.L1-N.voltage: 248
input.L2-N.voltage: 245
input.L3-N.voltage: 245
```