### PR TITLE
Fix Docker based build process by moving it to Alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ### STAGE 1: Build ###
 
-FROM golang:1-bullseye as builder
+FROM golang:1-alpine as builder
 
 WORKDIR /app
 COPY . /app


### PR DESCRIPTION
The `nut_exporter` binary was being built on a libc based distribution, which resulted in it failing to run on the Alpine container.

Fixes #40 

Please note that #33 is very similar, it is just not documented.
That MR also removes a compatibility package, which may not be needed anymore, but I didn't go as far as removing it as I don't know the implications.