### PR TITLE
release-helm should trigger on master branch

### DIFF
--- a/.github/workflows/release-helm.yml
+++ b/.github/workflows/release-helm.yml
@@ -3,7 +3,7 @@ name: Release Helm Chart
 on:
   push:
     branches:
-      - main
+      - master
 
 jobs:
   release:


### PR DESCRIPTION
This repo has a master branch and not a main branch. Changing this will trigger a helm release.
Fix for issue https://github.com/DRuggeri/nut_exporter/issues/58