### PR TITLE
Fix; module version tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ $ ./nut_exporter <flags>
 Using the standard `go install` (you must have [Go](https://golang.org/) already installed in your local machine):
 
 ```bash
-$ go install github.com/DRuggeri/nut_exporter
+$ go install github.com/DRuggeri/nut_exporter/v3@latest
 $ nut_exporter <flags>
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/DRuggeri/nut_exporter
+module github.com/DRuggeri/nut_exporter/v3
 
 go 1.22
 

--- a/nut_exporter.go
+++ b/nut_exporter.go
@@ -16,7 +16,7 @@ import (
 	"github.com/prometheus/exporter-toolkit/web"
 	"github.com/prometheus/exporter-toolkit/web/kingpinflag"
 
-	"github.com/DRuggeri/nut_exporter/collectors"
+	"github.com/DRuggeri/nut_exporter/v3/collectors"
 )
 
 var Version = "testing"


### PR DESCRIPTION
This pull request fixes the installation via `go install` which currently [still sees v1.2.0 as the latest version](https://pkg.go.dev/github.com/DRuggeri/nut_exporter). Also updated the readme for this given the installation steps are slightly different for other major versions.

After this change `go install github.com/DRuggeri/nut_exporter@latest` will still result in installing v1.2.0 but will also allow one to install any future latest v3 releases (like v3.2.2) with `go install github.com/DRuggeri/nut_exporter/v3@latest`.