### PR TITLE
Fix: Remove erroneous continue statement preventing string regex metrics from being exported

### DIFF
--- a/collectors/nut_collector.go
+++ b/collectors/nut_collector.go
@@ -251,7 +251,6 @@ func (c *NutCollector) Collect(ch chan<- prometheus.Metric) {
 						c.logger.Debug("Cannot convert string to binary 0/1", "value", variable.Value.(string))
 						continue
 					}
-					continue
 				default:
 					c.logger.Warn("Unknown variable type from nut client library", "name", variable.Name, "type", fmt.Sprintf("%T", v), "claimed_type", variable.Type, "value", v)
 					continue


### PR DESCRIPTION
When string variables matched the on_regex or off_regex patterns, they were
successfully converted to numeric values (0 or 1), but a continue statement
immediately after the conversion logic prevented the metrics from being
exported to Prometheus.

This fix removes the extra continue statement, allowing string variables
that match the regex patterns to be properly exported as metrics.